### PR TITLE
[Hotfix]: changed model type in llm_routing for router

### DIFF
--- a/agentic-patterns/llm_routing.py
+++ b/agentic-patterns/llm_routing.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
         agent = Agent(
             model=BedrockModel(
-                model_id="amazon.nova-lite-v1:0",
+                model_id="amazon.nova-pro-v1:0",
                 temperature=0.9,
             ),
             system_prompt="You are a fast, efficient assistant for basic programming questions. Provide concise, accurate answers about syntax, commands, and simple explanations.",


### PR DESCRIPTION
Because nova lite has no structured output support I changed the router to nova pro.